### PR TITLE
Better support for variable product sync

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -1,5 +1,5 @@
 === Clerk ===
-Contributors: clerkio
+Contributors: clerkio, audunhus
 Tags: product recommendations, semantic search, customer conversion, customer retention, customer segmentation, webshop personalization, sales optimisation
 License: MIT
 License URI: https://opensource.org/licenses/MIT


### PR DESCRIPTION
## Implemented better support for variable products.
Closes issue #2 

If variable product has two variations and only the most expensive one is on sale, then the cheapest variable product info will be sent. If that variable product is not on sale the on_sale flag is not set.

Tested on Mobilverkstedet.no