### PR TITLE
Fix undefined collect_baskets notice

### DIFF
--- a/includes/class-clerk-basket.php
+++ b/includes/class-clerk-basket.php
@@ -22,7 +22,7 @@ class Clerk_Basket {
 	private function initHooks() {
 
         $options = get_option('clerk_options');
-        if (!$options['collect_baskets']) {
+        if (!isset($options['collect_baskets'])) {
             return;
         }
 


### PR DESCRIPTION
If option Collect Baskets is not set it gives an php notice on every pages.

`Notice: Undefined index: collect_baskets in ****/plugins/clerkio/includes/class-clerk-basket.php on line 25`