### PR TITLE
Replace deprecated order date function

### DIFF
--- a/includes/class-clerk-rest-api.php
+++ b/includes/class-clerk-rest-api.php
@@ -789,7 +789,7 @@ class Clerk_Rest_Api extends WP_REST_Server
 
                 $order_object = [
                     'products' => $order_items,
-                    'time' => strtotime($order->order_date),
+                    'time' => strtotime(gmdate('Y-m-d H:i:s', $order->get_date_created()->getOffsetTimestamp())),
                     'class' => get_class($order)
                 ];
 


### PR DESCRIPTION
The plugin is accessing order properties directly, it should instead use order functions to get the data.
This causes a lot of warnings:

> order_date was called incorrectly. Order properties should not be accessed directly. Backtrace: require('wp-blog-header.php'), wp, WP->main, WP->parse_request, do_action_ref_array('parse_request'), WP_Hook->do_action, WP_Hook->apply_filters, rest_api_loaded, WP_REST_Server->serve_request, WP_REST_Server->dispatch, Clerk_Rest_Api->order_endpoint_callback, WC_Abstract_Legacy_Order->__get, wc_doing_it_wrong. This message was added in version 3.0.

My pull request should solve the problem and get rid of all the related warnings.