### PR TITLE
Don't access order properties directly

### DIFF
--- a/includes/class-clerk-rest-api.php
+++ b/includes/class-clerk-rest-api.php
@@ -958,7 +958,12 @@ class Clerk_Rest_Api extends WP_REST_Server
 
                 //Include email if defined
                 if ($options['collect_emails'] !== null && $options['collect_emails']) {
-                    $order_object['email'] = $order->billing_email;
+                    //billing_email is a protected property in 3.0
+                    if (clerk_check_version()) {
+                        $order_object['email'] = $order->get_billing_email();
+                    } else {
+                        $order_object['email'] = $order->billing_email;
+                    }
                 }
 
                 //id is a protected property in 3.0


### PR DESCRIPTION
Fix for Order properties should not be accessed directly in the rest apo