### PR TITLE
Feature and Fix Merge

### DIFF
--- a/clerk.php
+++ b/clerk.php
@@ -3,7 +3,7 @@
  * Plugin Name: Clerk
  * Plugin URI: https://clerk.io/
  * Description: Clerk.io Turns More Browsers Into Buyers
- * Version: 3.6.2
+ * Version: 3.7.0
  * Author: Clerk.io
  * Author URI: https://clerk.io
  *

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "clerkio/woocommerce",
   "description": "Clerk.io Turns More Browsers Into Buyers",
-  "version": "3.6.2",
+  "version": "3.7.0",
   "keywords": ["WordPress"],
   "authors": [
     {

--- a/includes/class-clerk-admin-settings.php
+++ b/includes/class-clerk-admin-settings.php
@@ -20,7 +20,7 @@ class Clerk_Admin_Settings
         $this->initHooks();
         require_once(__DIR__ . '/class-clerk-logger.php');
         $this->logger = new ClerkLogger();
-        $this->version = '3.6.2';
+        $this->version = '3.7.0';
 
         $this->InitializeSettings();
 

--- a/includes/class-clerk-admin-settings.php
+++ b/includes/class-clerk-admin-settings.php
@@ -651,13 +651,13 @@ class Clerk_Admin_Settings
             ]
         );
 
-        add_settings_field('livesearch_include_categories',
-            __('Include Categories', 'clerk'),
+        add_settings_field('livesearch_include_suggestions',
+            __('Include Suggestions', 'clerk'),
             [$this, 'addCheckboxField'],
             'clerk',
             'clerk_section_livesearch',
             [
-                'label_for' => 'livesearch_include_categories',
+                'label_for' => 'livesearch_include_suggestions',
                 'checked' => 0
             ]
         );
@@ -673,6 +673,17 @@ class Clerk_Admin_Settings
             ]
         );
 
+        add_settings_field('livesearch_include_categories',
+            __('Include Categories', 'clerk'),
+            [$this, 'addCheckboxField'],
+            'clerk',
+            'clerk_section_livesearch',
+            [
+                'label_for' => 'livesearch_include_categories',
+                'checked' => 0
+            ]
+        );
+
         add_settings_field('livesearch_categories',
             __('Number of Categories', 'clerk'),
             [$this, 'add1_10Dropdown'],
@@ -681,6 +692,17 @@ class Clerk_Admin_Settings
             [
                 'label_for' => 'livesearch_categories',
                 'default' => 5
+            ]
+        );
+
+        add_settings_field('livesearch_include_pages',
+            __('Include Pages', 'clerk'),
+            [$this, 'addCheckboxField'],
+            'clerk',
+            'clerk_section_livesearch',
+            [
+                'label_for' => 'livesearch_include_pages',
+                'checked' => 0
             ]
         );
 

--- a/includes/class-clerk-admin-settings.php
+++ b/includes/class-clerk-admin-settings.php
@@ -1626,15 +1626,16 @@ class Clerk_Admin_Settings
                 #wpbody {
                     background-color: #DEDEDE;
                     padding-left: 1rem;
-                    border-left: 1px solid #444;
+                    border-left: 1px solid #1d2327;
                 }
 
                 #wpbody form {
                     background-color: #eee;
-                    padding: 1rem;
-                    border: 1px solid #444;
+                    padding: 0rem 1rem 1rem 1rem;
+                    border: 1px solid #1d2327;
                     border-radius: 5px;
                     margin-top: 1rem;
+                    box-shadow: 0 3px 3px rgba(0,0,0,0.2);
                 }
                 #wpbody label {
                     cursor: default;
@@ -1646,6 +1647,13 @@ class Clerk_Admin_Settings
                     width: -webkit-fill-available;  /* Mozilla-based browsers will ignore this. */
                     width: fill-available;
                     max-width: clamp(300px, 50%, 100%);
+                }
+
+                #wpbody h2 {
+                    background: #1d2327;
+                    padding: 1rem;
+                    margin: 0 -1rem;
+                    color: white;
                 }
 
                 #clerkFloatingSaveBtn {

--- a/includes/class-clerk-admin-settings.php
+++ b/includes/class-clerk-admin-settings.php
@@ -520,6 +520,145 @@ class Clerk_Admin_Settings
                 'label_for' => 'data_sync_image_size',
             ]
         );
+
+
+                //Add livesearch section
+                add_settings_section(
+                    'clerk_section_livesearch',
+                    __('Live search Settings', 'clerk'),
+                    null,
+                    'clerk');
+        
+                add_settings_field('livesearch_enabled',
+                    __('Enabled', 'clerk'),
+                    [$this, 'addCheckboxField'],
+                    'clerk',
+                    'clerk_section_livesearch',
+                    [
+                        'label_for' => 'livesearch_enabled',
+                        'checked' => 0
+                    ]
+                );
+        
+                add_settings_field('livesearch_include_suggestions',
+                    __('Include Suggestions', 'clerk'),
+                    [$this, 'addCheckboxField'],
+                    'clerk',
+                    'clerk_section_livesearch',
+                    [
+                        'label_for' => 'livesearch_include_suggestions',
+                        'checked' => 0
+                    ]
+                );
+        
+                add_settings_field('livesearch_suggestions',
+                    __('Number of Suggestions', 'clerk'),
+                    [$this, 'add1_10Dropdown'],
+                    'clerk',
+                    'clerk_section_livesearch',
+                    [
+                        'label_for' => 'livesearch_suggestions',
+                        'default' => 5
+                    ]
+                );
+        
+                add_settings_field('livesearch_include_categories',
+                    __('Include Categories', 'clerk'),
+                    [$this, 'addCheckboxField'],
+                    'clerk',
+                    'clerk_section_livesearch',
+                    [
+                        'label_for' => 'livesearch_include_categories',
+                        'checked' => 0
+                    ]
+                );
+        
+                add_settings_field('livesearch_categories',
+                    __('Number of Categories', 'clerk'),
+                    [$this, 'add1_10Dropdown'],
+                    'clerk',
+                    'clerk_section_livesearch',
+                    [
+                        'label_for' => 'livesearch_categories',
+                        'default' => 5
+                    ]
+                );
+        
+                add_settings_field('livesearch_include_pages',
+                    __('Include Pages', 'clerk'),
+                    [$this, 'addCheckboxField'],
+                    'clerk',
+                    'clerk_section_livesearch',
+                    [
+                        'label_for' => 'livesearch_include_pages',
+                        'checked' => 0
+                    ]
+                );
+        
+                add_settings_field('livesearch_pages',
+                    __('Number of Pages', 'clerk'),
+                    [$this, 'add1_10Dropdown'],
+                    'clerk',
+                    'clerk_section_livesearch',
+                    [
+                        'label_for' => 'livesearch_pages',
+                        'default' => 5
+                    ]
+                );
+        
+                add_settings_field('livesearch_pages_type',
+                    __('Pages Type', 'clerk'),
+                    [$this, 'addPagesTypeDropdown'],
+                    'clerk',
+                    'clerk_section_livesearch',
+                    [
+                        'label_for' => 'livesearch_pages_type',
+                    ]
+                );
+        
+                add_settings_field('livesearch_dropdown_position',
+                    __('Dropdown Positioning', 'clerk'),
+                    [$this, 'addDropdownPosition'],
+                    'clerk',
+                    'clerk_section_livesearch',
+                    [
+                        'label_for' => 'livesearch_dropdown_position',
+                    ]
+                );
+        
+                add_settings_field('livesearch_field_selector',
+                    __('Live Search Input Selector', 'clerk'),
+                    [$this, 'addTextField'],
+                    'clerk',
+                    'clerk_section_livesearch',
+                    [
+                        'label_for' => 'livesearch_field_selector',
+                        'default' => '.search-field'
+                    ]
+                );
+        
+                add_settings_field('livesearch_form_selector',
+                    __('Live Search Form Selector', 'clerk'),
+                    [$this, 'addTextField'],
+                    'clerk',
+                    'clerk_section_livesearch',
+                    [
+                        'label_for' => 'livesearch_form_selector',
+                        'default' => '[role="search"]'
+                    ]
+                );
+        
+                add_settings_field('livesearch_template',
+                    __('Content', 'clerk'),
+                    [$this, 'addTextField'],
+                    'clerk',
+                    'clerk_section_livesearch',
+                    [
+                        'label_for' => 'livesearch_template',
+                    ]
+                );
+
+
         //Add search section
         add_settings_section(
             'clerk_section_search',
@@ -630,142 +769,6 @@ class Clerk_Admin_Settings
             'clerk_section_search',
             [
                 'label_for' => 'search_load_more_button',
-            ]
-        );
-
-        //Add livesearch section
-        add_settings_section(
-            'clerk_section_livesearch',
-            __('Live search Settings', 'clerk'),
-            null,
-            'clerk');
-
-        add_settings_field('livesearch_enabled',
-            __('Enabled', 'clerk'),
-            [$this, 'addCheckboxField'],
-            'clerk',
-            'clerk_section_livesearch',
-            [
-                'label_for' => 'livesearch_enabled',
-                'checked' => 0
-            ]
-        );
-
-        add_settings_field('livesearch_include_suggestions',
-            __('Include Suggestions', 'clerk'),
-            [$this, 'addCheckboxField'],
-            'clerk',
-            'clerk_section_livesearch',
-            [
-                'label_for' => 'livesearch_include_suggestions',
-                'checked' => 0
-            ]
-        );
-
-        add_settings_field('livesearch_suggestions',
-            __('Number of Suggestions', 'clerk'),
-            [$this, 'add1_10Dropdown'],
-            'clerk',
-            'clerk_section_livesearch',
-            [
-                'label_for' => 'livesearch_suggestions',
-                'default' => 5
-            ]
-        );
-
-        add_settings_field('livesearch_include_categories',
-            __('Include Categories', 'clerk'),
-            [$this, 'addCheckboxField'],
-            'clerk',
-            'clerk_section_livesearch',
-            [
-                'label_for' => 'livesearch_include_categories',
-                'checked' => 0
-            ]
-        );
-
-        add_settings_field('livesearch_categories',
-            __('Number of Categories', 'clerk'),
-            [$this, 'add1_10Dropdown'],
-            'clerk',
-            'clerk_section_livesearch',
-            [
-                'label_for' => 'livesearch_categories',
-                'default' => 5
-            ]
-        );
-
-        add_settings_field('livesearch_include_pages',
-            __('Include Pages', 'clerk'),
-            [$this, 'addCheckboxField'],
-            'clerk',
-            'clerk_section_livesearch',
-            [
-                'label_for' => 'livesearch_include_pages',
-                'checked' => 0
-            ]
-        );
-
-        add_settings_field('livesearch_pages',
-            __('Number of Pages', 'clerk'),
-            [$this, 'add1_10Dropdown'],
-            'clerk',
-            'clerk_section_livesearch',
-            [
-                'label_for' => 'livesearch_pages',
-                'default' => 5
-            ]
-        );
-
-        add_settings_field('livesearch_pages_type',
-            __('Pages Type', 'clerk'),
-            [$this, 'addPagesTypeDropdown'],
-            'clerk',
-            'clerk_section_livesearch',
-            [
-                'label_for' => 'livesearch_pages_type',
-            ]
-        );
-
-        add_settings_field('livesearch_dropdown_position',
-            __('Dropdown Positioning', 'clerk'),
-            [$this, 'addDropdownPosition'],
-            'clerk',
-            'clerk_section_livesearch',
-            [
-                'label_for' => 'livesearch_dropdown_position',
-            ]
-        );
-
-        add_settings_field('livesearch_field_selector',
-            __('Live Search Input Selector', 'clerk'),
-            [$this, 'addTextField'],
-            'clerk',
-            'clerk_section_livesearch',
-            [
-                'label_for' => 'livesearch_field_selector',
-                'default' => '.search-field'
-            ]
-        );
-
-        add_settings_field('livesearch_form_selector',
-            __('Live Search Form Selector', 'clerk'),
-            [$this, 'addTextField'],
-            'clerk',
-            'clerk_section_livesearch',
-            [
-                'label_for' => 'livesearch_form_selector',
-                'default' => '[role="search"]'
-            ]
-        );
-
-        add_settings_field('livesearch_template',
-            __('Content', 'clerk'),
-            [$this, 'addTextField'],
-            'clerk',
-            'clerk_section_livesearch',
-            [
-                'label_for' => 'livesearch_template',
             ]
         );
 

--- a/includes/class-clerk-admin-settings.php
+++ b/includes/class-clerk-admin-settings.php
@@ -1031,7 +1031,7 @@ class Clerk_Admin_Settings
             ]
         );
         add_settings_field('clerk_cart_shortcode',
-            __('Product ID Shortcode', 'clerk'),
+            __('Cart IDs Shortcode', 'clerk'),
             [$this, 'addTextField'],
             'clerk',
             'clerk_section_cart',

--- a/includes/class-clerk-logger.php
+++ b/includes/class-clerk-logger.php
@@ -99,7 +99,7 @@ class ClerkLogger
                     $args = array(
                         'body'        => $data_string,
                         'method'      => 'POST',
-                        'headers'     => array('User-Agent' => 'ClerkExtensionBot WooCommerce/v' .get_bloginfo('version'). ' Clerk/v3.6.2 PHP/v'.phpversion())
+                        'headers'     => array('User-Agent' => 'ClerkExtensionBot WooCommerce/v' .get_bloginfo('version'). ' Clerk/v3.7.0 PHP/v'.phpversion())
                     );
 
                     wp_remote_request( $Endpoint, $args );
@@ -159,7 +159,7 @@ class ClerkLogger
                 $args = array(
                     'body' => $data_string,
                     'method' => 'POST',
-                    'headers' => array('User-Agent' => 'ClerkExtensionBot WooCommerce/v' . get_bloginfo('version') . ' Clerk/v3.6.2 PHP/v' . phpversion())
+                    'headers' => array('User-Agent' => 'ClerkExtensionBot WooCommerce/v' . get_bloginfo('version') . ' Clerk/v3.7.0 PHP/v' . phpversion())
                 );
 
                 wp_remote_request($Endpoint, $args);
@@ -223,7 +223,7 @@ class ClerkLogger
                     $args = array(
                         'body'        => $data_string,
                         'method'      => 'POST',
-                        'headers'     => array('User-Agent' => 'ClerkExtensionBot WooCommerce/v' .get_bloginfo('version'). ' Clerk/v3.6.2 PHP/v'.phpversion())
+                        'headers'     => array('User-Agent' => 'ClerkExtensionBot WooCommerce/v' .get_bloginfo('version'). ' Clerk/v3.7.0 PHP/v'.phpversion())
                     );
 
                     wp_remote_request( $Endpoint, $args );

--- a/includes/class-clerk-visitor-tracking.php
+++ b/includes/class-clerk-visitor-tracking.php
@@ -160,14 +160,26 @@ class Clerk_Visitor_Tracking {
                 <span
                         class="clerk"
                         data-template="@<?php echo esc_attr( strtolower( str_replace( ' ', '-', $options['livesearch_template'] ) ) ); ?>"
-                        data-instant-search-suggestions="<?php echo $options['livesearch_suggestions']; ?>"
-                        data-instant-search-categories="<?php echo $options['livesearch_categories']; ?>"
-                        data-instant-search-pages="<?php echo $options['livesearch_pages']; ?>"
+                        <?php
+                        if ( isset( $options['livesearch_suggestions'] ) && isset( $options['livesearch_include_suggestions'])) :
+                            ?>
+                                data-instant-search-suggestions="<?php echo $options['livesearch_suggestions']; ?>"
+                            <?php
+                        endif;
+                        if ( isset( $options['livesearch_categories'] ) && isset( $options['livesearch_include_categories'])) :
+                            ?>
+                                data-instant-search-categories="<?php echo $options['livesearch_categories']; ?>"
+                            <?php
+                        endif;
+                        ?>
                         data-instant-search-positioning="<?php echo strtolower($options['livesearch_dropdown_position']); ?>"
                         <?php
-
-                        if ( isset( $options['livesearch_pages_type'] ) && $options['livesearch_pages_type'] != 'All') :
-
+                        if ( isset( $options['livesearch_pages'] ) && isset( $options['livesearch_include_pages'])) :
+                        ?>
+                            data-instant-search-pages="<?php echo $options['livesearch_pages']; ?>"
+                        <?php
+                        endif;
+                        if ( isset( $options['livesearch_pages_type'] ) && $options['livesearch_pages_type'] != 'All' && isset( $options['livesearch_include_pages'])) :
                             ?>
                             data-instant-search-pages-type="<?php echo $options['livesearch_pages_type']; ?>"
                         <?php

--- a/readme.txt
+++ b/readme.txt
@@ -29,7 +29,7 @@ Once signed up, simply login to your my.clerk.io backend, which will guide you t
 
 
 == Changelog ==
-= 3.6.2 - 2022-06-15 =
+= 3.7.0 - 2022-06-15 =
 * Added Exclude checkbox for all recs, and added filter to span generation.
 * Added default lists with variable product data, similar to shopify.
 * Added selector for image size to sync in admin.


### PR DESCRIPTION
Added Exclude checkbox for all recs, and added filter to span generation.

Added default lists with variable product data, similar to shopify.

Added selector for image size to sync in admin.

Added checkbox to enabled or disable pages in search page embedcode.

Added sync method for subscriber type users, without historic orders.

Added checkbox injection with custom message for log/subscriber from checkout page. This is a feature parity thing, with mailchimp/woocommerce mail module.

Added shortcodes to allow printing, product, category and cart ids in templating engines like elementor.

Codes are:
[clerk_product_id]
[clerk_category_id]
[clerk_cart_ids]

Fixed position of cart page slider, by changing hook position. Before it would get removed if the client used ajax cart, and edited their cart contents. Placement also overflowed checkout button on mobile.

Added better tax handling on order tracking page, to allow us to work seamlessly with geoip modules.

Fixed page type set wrong for All option on search page.

Added sanity check for attribute keys with dashes, to make them compatible with our feed structure.

Improved admin panel UX, with some colors, log and spacing, as well as a floating save button to avoid having to scroll our extensive settings to the bottom to save.