### PR TITLE
Don't send active variations to Clerk when parent is not published

### DIFF
--- a/includes/class-clerk-product-sync.php
+++ b/includes/class-clerk-product-sync.php
@@ -53,6 +53,21 @@ class Clerk_Product_Sync {
             }
 
             if (clerk_check_version()) {
+		    
+		//Don't send variations when parent is not published
+                if ($product->is_type('variation')) {
+                    $parent = wc_get_product($product->get_parent_id());
+
+                    if (!$parent) {
+                        return;
+                    }
+
+                    if ($parent->get_status() !== 'publish') {
+                        $this->remove_product($product->get_id());
+                        return;
+                    }
+                }
+		    
                 if ($product->get_status() === 'publish') {
                     //Send product to Clerk
                     $this->add_product($product);
@@ -69,7 +84,7 @@ class Clerk_Product_Sync {
 
                     }
 
-                } elseif (!$product->get_status() === 'draft') {
+                } else {
                     //Remove product
                     $this->remove_product($product->get_id());
                 }


### PR DESCRIPTION
Fixes an issue where updating a not published parent product manually from the dashboard or programmatically from `$product->save()` would send all active variations of that product to Clerk. This is not something one would want given that the parent is not published.

Also changed the logic a bit to remove products that are not published. Why would you not remove a product that is set from published to draft? You would not want drafted products in live search etc.