### PR TITLE
admin-ajax.php - by default - is *not* located at the hardcoded path

### DIFF
--- a/includes/class-clerk-visitor-tracking.php
+++ b/includes/class-clerk-visitor-tracking.php
@@ -247,7 +247,7 @@ class Clerk_Visitor_Tracking {
             
                                 request = jQuery.ajax({
                                                 type : "POST",
-                                                url  : "/wordpress/wp-admin/admin-ajax.php",
+                                                url  : "<?php echo admin_url( 'admin-ajax.php' ); ?>",
                                                 data: {
                                                     action:'get_cart'
                                                 }, 
@@ -334,7 +334,7 @@ class Clerk_Visitor_Tracking {
                                     }
                                     });
 
-                                    request.open('POST', "/wordpress/wp-admin/admin-ajax.php", true);
+                                    request.open('POST', "<?php echo admin_url( 'admin-ajax.php' ); ?>", true);
                                     request.setRequestHeader('Content-Type', 'application/x-www-form-urlencoded; charset=UTF-8');
                                     request.send(data);
                         


### PR DESCRIPTION
/wordpress/wp-admin/admin-ajax.php
is not necessarily the path to every clients admin-ajax.
In fact, it's not even the default.

I propose this path should be determined dynamically instead.