### PR TITLE
Update class-clerk-powerstep.php

### DIFF
--- a/includes/class-clerk-powerstep.php
+++ b/includes/class-clerk-powerstep.php
@@ -50,7 +50,7 @@ class Clerk_Powerstep {
 		$options = get_option( 'clerk_options' );
 
 		// if powerstep disabled, there's no need to init hooks.
-		if ( ! isset( $options['powerstep_enabled'] ) ) {
+		if ( ! $options['powerstep_enabled'] ) {
 			return false;
 		}
 


### PR DESCRIPTION
Fix faulty check for enabled powerstep causing issues with add-to-cart functionality. Since powerstep_enabled is always set we can't check with isset.