### PR TITLE
Instantiate class as globally available object

### DIFF
--- a/includes/class-clerk-product-sync.php
+++ b/includes/class-clerk-product-sync.php
@@ -632,4 +632,4 @@ class Clerk_Product_Sync {
 	}
 }
 
-new Clerk_Product_Sync();
+$clerk_product_sync = new Clerk_Product_Sync();


### PR DESCRIPTION
By instantiating the class as a globally available object, we can use this object to remove actions added inside the class like this:

remove_action( 'woocommerce_update_product', array( $clerk_product_sync, 'save_product' ), 10, 3 );

This is useful when syncing products from other systems without firing Clerk API calls 15 000 times in a row when not needed.