### PR TITLE
feat: one can disable powerstep programmatically

### DIFF
--- a/includes/class-clerk-powerstep.php
+++ b/includes/class-clerk-powerstep.php
@@ -70,6 +70,12 @@ class Clerk_Powerstep {
 	 * @param string $url Powerstep Url.
 	 */
 	public function redirect_to_powerstep( $url ) {
+		$powerstep_enabled = apply_filters( 'clerk_powerstep_enabled' , true );
+
+		// Check a filter so we can disable clerk popup programmatically
+		if (!$powerstep_enabled) {
+			return false;
+		}
 
 		try {
 			$add_to_cart_param = false;
@@ -115,6 +121,12 @@ class Clerk_Powerstep {
 	 * @param string $url Powerstep Url.
 	 */
 	public function redirect_to_powerstep_no_ajax( $url ) {
+		$powerstep_enabled = apply_filters( 'clerk_powerstep_enabled' , true );
+
+		// Check a filter so we can disable clerk popup programmatically
+		if (!$powerstep_enabled) {
+			return false;
+		}
 
 		try {
 


### PR DESCRIPTION
# This PR adds
* Feature to disable powerstep programmatically.

## Usage
```php
add_filter('clerk_powerstep_enabled', function ($powerstep_enabled) {
    if (condition) {
        return false;
    }
    return $powerstep_enabled;
}, 10, 1);

```

To test this i've applied a git patch on one of the site running in production and seems to be working like a charm!
