### PR TITLE
feat: one can disable clerk programmatically

### DIFF
--- a/includes/class-clerk-visitor-tracking.php
+++ b/includes/class-clerk-visitor-tracking.php
@@ -125,6 +125,12 @@ class Clerk_Visitor_Tracking {
 
 			$options = get_option( 'clerk_options' );
 
+			// Add a filter so we can disable clerk programmatically or check if public key is set
+			$clerk_enabled = apply_filters( 'clerk_enabled', true );
+			if (!$clerk_enabled || !$options['public_key']) {
+				return false;
+			}
+
 			// Default to true.
 			if ( ! isset( $options['collect_emails'] ) ) {
 				$options['collect_emails'] = true;

--- a/includes/class-clerk-visitor-tracking.php
+++ b/includes/class-clerk-visitor-tracking.php
@@ -127,7 +127,8 @@ class Clerk_Visitor_Tracking {
 
 			// Add a filter so we can disable clerk programmatically or check if public key is set
 			$clerk_enabled = apply_filters( 'clerk_enabled', true );
-			if (!$clerk_enabled || !$options['public_key']) {
+			$public_key_not_set = ! isset( $options['public_key'] ) || ( isset( $options['public_key'] ) && ! $options['public_key'] );
+			if (!$clerk_enabled || $public_key_not_set) {
 				return false;
 			}
 


### PR DESCRIPTION
# This PR adds
* Feature to disable clerk programatically
* Solves issue - When plugin is activated and not configured. It throws lots of warning for public_key being empty on all pages. So added a condition to avoid those warnings.

## Usage
```php
add_filter('clerk_enabled', function($clerk_enabled) {
    if (condition) {
        return false;
    }
    return $clerk_enabled;
}, 10, 1);
```

To test this i've applied a git patch on one of the site running in production and seems to be working like a charm!