### PR TITLE
feat: bail if realtime_updates key is not set in $options

### DIFF
--- a/includes/class-clerk-product-sync.php
+++ b/includes/class-clerk-product-sync.php
@@ -220,7 +220,7 @@ class Clerk_Product_Sync {
 		try {
 			$options = get_option( 'clerk_options' );
 
-			if ( ! is_array( $options ) ) {
+			if ( ! is_array( $options ) || ! isset( $options['realtime_updates'] ) ) {
 				return;
 			}
 


### PR DESCRIPTION
Fixes #71

We have realtime_updates turned off in our plugin's settings. As we don't want it.

Whenever there's an update to product it throws this errors.

This PR fixes it.