### PR TITLE
fix: php error call to member function on bool

### DIFF
--- a/includes/class-clerk-realtime-updates.php
+++ b/includes/class-clerk-realtime-updates.php
@@ -518,6 +518,9 @@ class Clerk_Product_Sync {
 						$child_ids           = $product->get_children();
 						foreach ( $child_ids as $key => $value ) {
 							$child                 = wc_get_product( $value );
+							if ( empty( $child ) ) {
+								continue;
+							}
 							$tmp_children_prices[] = $child->get_regular_price();
 						}
 						if ( ! empty( $tmp_children_prices ) ) {


### PR DESCRIPTION
In some cases `wc_get_product()` returns `false`. This results in `Call to a member function get_regular_price() on bool` on the following line. This PR inserts a guard statement to avoid this.