### PR TITLE
fix: php error call to member function on bool

### DIFF
--- a/includes/class-clerk-rest-api.php
+++ b/includes/class-clerk-rest-api.php
@@ -492,6 +492,9 @@ class Clerk_Rest_Api extends WP_REST_Server {
 							$child_ids           = $product->get_children();
 							foreach ( $child_ids as $key => $value ) {
 								$child                 = wc_get_product( $value );
+								if ( ! empty($child) ) {
+									continue;
+								}
 								$tmp_children_prices[] = $child->get_regular_price();
 							}
 							if ( ! empty( $tmp_children_prices ) ) {


### PR DESCRIPTION
In some cases `wc_get_product()` returns `false`. This results in `Call to a member function get_regular_price() on bool` on the following line. This PR inserts a guard statement to avoid this. Same as #85.